### PR TITLE
Update to R 4.2.1 and other package updates

### DIFF
--- a/repos/stable/rstudio/Chart.yaml
+++ b/repos/stable/rstudio/Chart.yaml
@@ -6,6 +6,6 @@ maintainers:
   email: system@uninett.no
 home: https://www.rstudio.com/products/RStudio/
 icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo.svg
-version: 0.2.20
+version: 0.2.21
 keywords:
   - R web IDE

--- a/repos/stable/rstudio/package_versions.json
+++ b/repos/stable/rstudio/package_versions.json
@@ -1,7 +1,7 @@
 {
   "packageVersions": {
-    "pkg-r-version": "4.1.2",
-    "pkg-rstudio-version": "2022.02.0+443",
-    "pkg-shiny-version": "1.5.17.973"
+    "pkg-r-version": "4.2.1",
+    "pkg-rstudio-version": "2022.02.3+492",
+    "pkg-shiny-version": "1.5.18.987"
   }
 }

--- a/repos/stable/rstudio/schema.yaml
+++ b/repos/stable/rstudio/schema.yaml
@@ -11,7 +11,7 @@ properties:
       dockerImage:
         type: string
         examples:
-        - quay.io/nird-toolkit/rstudio-server:20220301-bdfbd66
+        - quay.io/nird-toolkit/rstudio-server:20220705-ab3ec78
   appstore_generated_data:
     type: object
     properties:

--- a/repos/stable/rstudio/values.yaml
+++ b/repos/stable/rstudio/values.yaml
@@ -31,7 +31,7 @@ appstore_generated_data:
       - ""
 advanced:
   debug: false
-  dockerImage: quay.io/nird-toolkit/rstudio-server:20220301-bdfbd66
+  dockerImage: quay.io/nird-toolkit/rstudio-server:20220705-ab3ec78
   proxyImage: quay.io/nird-toolkit/rstudio-proxy:20220301-61f06ae
 authGroupProviders:
   - url: "https://groups-api.dataporten.no/groups/me/groups"


### PR DESCRIPTION
Changes Docker image in stable to an image with the following package updates:
- R from 4.1.2 to 4.2.1
- rstudio from 2022.02.0+443 to 2022.02.3+492
- shiny from 1.5.17.973 to 1.5.18.987

These changes are also added to rstudio testing version 0.2.97.