### PR TITLE
Upgrade to RStudio 2023.09.1+494

### DIFF
--- a/repos/stable/rstudio/Chart.yaml
+++ b/repos/stable/rstudio/Chart.yaml
@@ -5,7 +5,7 @@ maintainers:
 - name: Uninett AS
   email: system@uninett.no
 home: https://www.rstudio.com/products/RStudio/
-icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo.svg
-version: 1.1.0
+icon: https://rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-flat.svg
+version: 1.2.0
 keywords:
   - R web IDE

--- a/repos/stable/rstudio/README.md
+++ b/repos/stable/rstudio/README.md
@@ -15,4 +15,4 @@ browser.
 ### Advanced
 This application uses the following Dockerfile:
 
-- [RStudio](https://github.com/UninettSigma2/helm-charts-dockerfiles/tree/aebf6bb/rstudio/server/Dockerfile)
+- [RStudio](https://github.com/UNINETTSigma2/helm-charts-dockerfiles/blob/34add323f236f1a6d4a2202383551875e1a11fca/rstudio/server/Dockerfile)

--- a/repos/stable/rstudio/schema.yaml
+++ b/repos/stable/rstudio/schema.yaml
@@ -11,7 +11,7 @@ properties:
       dockerImage:
         type: string
         examples:
-        - quay.io/nird-toolkit/rstudio-server:20220705-ab3ec78
+        - sigma2as/rstudio-server:20231117-34add32
   appstore_generated_data:
     type: object
     properties:

--- a/repos/stable/rstudio/templates/deployment.yaml
+++ b/repos/stable/rstudio/templates/deployment.yaml
@@ -162,8 +162,6 @@ spec:
         env:
         - name: TZ
           value: Europe/Oslo
-        - name: OWNER_ID
-          value: {{ .Values.appstore_generated_data.aai.owner }}
         - name: USER
           value: {{ .Values.username }}
         - name: USERNAME
@@ -213,7 +211,7 @@ spec:
           mountPropagation: HostToContainer
           readOnly: {{ .Values.persistentStorage.readOnly }}
           subPath: home/{{ .Values.username }}
-        {{- end }}
+        {{- end -}}
 
 
 {{ if ne .Values.persistentStorage.existingClaim "" }}

--- a/repos/stable/rstudio/templates/ingress.yaml
+++ b/repos/stable/rstudio/templates/ingress.yaml
@@ -27,7 +27,7 @@ spec:
             backend:
               service:
                 name: {{ template "fullname" . }}
-                port: 
+                port:
                   number: 8080
     - host: shiny-{{ .Values.ingress.host }}
       http:
@@ -37,5 +37,5 @@ spec:
             backend:
               service:
                 name: {{ template "fullname" . }}
-                port: 
+                port:
                   number: 3838

--- a/repos/stable/rstudio/values.yaml
+++ b/repos/stable/rstudio/values.yaml
@@ -38,14 +38,10 @@ appstore_generated_data:
       - profile
       - email
     authorized_principals: []
-    owner: provided-by-toolkit
-    userinfo_url: provided-by-tookit
-    token_url: provided-by-toolkit
-    auth_url: provided-by-toolkit
 advanced:
   debug: false
-  dockerImage: quay.io/nird-toolkit/rstudio-server:20220705-ab3ec78
-  proxyImage: quay.io/nird-toolkit/rstudio-proxy:20220301-61f06ae
+  dockerImage: sigma2as/rstudio-server:20231117-34add32
+  proxyImage: sigma2as/rstudio-proxy:20231117-eca0b21
 authGroupProviders:
   - url: "https://groups-api.dataporten.no/groups/me/groups"
     scope: groups


### PR DESCRIPTION
- Upgraded to RStudio 2023.09.1+494
- Also upgraded `rstudio-proxy` nginx version to `1.25.3-alpine` and tini to `0.19.0-r1`
- Configuration of `rstudio-proxy` was simplified a bit and made more similar to the configuration in the RStudio documentation
- Can be tested with chart version `0.3.3` in `sigma2-testing` repository