### PR TITLE
Updated newest image in testing to use latest docker image

### DIFF
--- a/repos/testing/rstudio/Chart.yaml
+++ b/repos/testing/rstudio/Chart.yaml
@@ -6,6 +6,6 @@ maintainers:
   email: contact@sigma2.no
 home: https://www.rstudio.com/products/RStudio/
 icon: https://upload.wikimedia.org/wikipedia/commons/d/d0/RStudio_logo_flat.svg
-version: 0.4.11
+version: 0.4.12
 keywords:
   - R web IDE

--- a/repos/testing/rstudio/README.md
+++ b/repos/testing/rstudio/README.md
@@ -15,4 +15,4 @@ browser.
 ### Advanced
 This application uses the following Dockerfile:
 
-- [RStudio](https://github.com/UNINETTSigma2/helm-charts-dockerfiles/tree/10a4268/rstudio/server/Dockerfile)
+- [RStudio](https://github.com/UNINETTSigma2/helm-charts-dockerfiles/tree/fcb4187/rstudio/server/Dockerfile)

--- a/repos/testing/rstudio/package_versions.json
+++ b/repos/testing/rstudio/package_versions.json
@@ -1,7 +1,7 @@
 {
   "packageVersions": {
-    "pkg-r-version": "4.2.1",
-    "pkg-rstudio-version": "2022.02.3+492",
-    "pkg-shiny-version": "1.5.18.987"
+    "pkg-r-version": "4.6.1",
+    "pkg-rstudio-version": "2026.08.0+187",
+    "pkg-shiny-version": "1.5.23.1030"
   }
 }

--- a/repos/testing/rstudio/schema.yaml
+++ b/repos/testing/rstudio/schema.yaml
@@ -11,7 +11,7 @@ properties:
       dockerImage:
         type: string
         examples:
-        - sigma2as/rstudio-server:20260611-10a4268
+        - sigma2as/rstudio-server:20260818-fcb4187
   appstore_generated_data:
     type: object
     properties:

--- a/repos/testing/rstudio/values.yaml
+++ b/repos/testing/rstudio/values.yaml
@@ -40,8 +40,8 @@ appstore_generated_data:
     authorized_principals: []
 advanced:
   debug: false
-  dockerImage: sigma2as/rstudio-server:20260611-10a4268
-  proxyImage: sigma2as/rstudio-proxy:20260528-76bfe3c
+  dockerImage: sigma2as/rstudio-server:20260818-fcb4187
+  proxyImage: sigma2as/rstudio-proxy:20260818-1df6a44
 authGroupProviders:
   - url: "https://groups-api.dataporten.no/groups/me/groups"
     scope: groups


### PR DESCRIPTION
Updated to rstudio 2026.08.0+187 and proxy to nginx:1.31.3-alpine. new image removes database.conf as permission errors made new rstudio version crash when trying to read the file.